### PR TITLE
IDENTITY-4793 : Improving credentials handling IWA federated authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
@@ -30,6 +30,10 @@
     <name>WSO2 Carbon - IWA Identity Application Authenticator</name>
     <dependencies>
         <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/AbstractIWAAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/AbstractIWAAuthenticator.java
@@ -87,27 +87,4 @@ public abstract class AbstractIWAAuthenticator extends AbstractApplicationAuthen
             throw new AuthenticationFailedException(msg, e);
         }
     }
-
-    protected void invalidateSession(HttpServletRequest request) {
-        if (request.isRequestedSessionIdValid()) {
-            // invalidate the session. ie. clear all attributes
-            request.getSession().invalidate();
-            // create a new session thereby creating a new jSessionID
-            request.getSession(true);
-        }
-    }
-
-
-    protected String getDomainAwareUserName(String fullyQualifiedUserName) throws AuthenticationFailedException {
-        if (StringUtils.isEmpty(fullyQualifiedUserName)) {
-            throw new AuthenticationFailedException("Authenticated user not found in GSS Token");
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug("Authenticated user(FQDN) extracted from kerberos ticket : " + fullyQualifiedUserName);
-        }
-        // remove the AD domain from the username
-        int index = fullyQualifiedUserName.lastIndexOf("@");
-        return fullyQualifiedUserName.substring(0, index);
-    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
@@ -78,7 +78,7 @@ public class IWAAuthenticationUtil {
             }
         }
 
-        if (StringUtils.isNotEmpty(servicePrincipalName) && !ArrayUtils.isEmpty(servicePrincipalPassword)) {
+        if (StringUtils.isNotEmpty(servicePrincipalName) && ArrayUtils.isNotEmpty(servicePrincipalPassword)) {
             CallbackHandler callbackHandler = getUserNamePasswordCallbackHandler(servicePrincipalName,
                     servicePrincipalPassword);
 

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
@@ -44,6 +44,7 @@ import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+import javax.servlet.http.HttpServletRequest;
 
 
 /**
@@ -58,21 +59,21 @@ public class IWAAuthenticationUtil {
     private static transient GSSCredential localIWACredentials;
     private static transient KerberosPrincipal serverPrincipal;
 
-    // Shared Map to hold IWA GSS credentials for respective Kerberos servers
-    private static transient Map<String, GSSCredential> gssCredentialMap = new ConcurrentHashMap<>();
     private static Log log = LogFactory.getLog(IWAAuthenticationUtil.class);
 
 
     public static void initializeIWALocalAuthenticator() throws GSSException, PrivilegedActionException, LoginException {
         RealmService realmService = dataHolder.getRealmService();
 
+        // TODO : read this config from a file in registry
         String servicePrincipalName =
                 realmService.getBootstrapRealmConfiguration().getUserStoreProperty(IWAConstants.SPN_NAME);
         String servicePrincipalPassword =
                 realmService.getBootstrapRealmConfiguration().getUserStoreProperty(IWAConstants.SPN_PASSWORD);
 
         if (StringUtils.isNotEmpty(servicePrincipalName) && StringUtils.isNotEmpty(servicePrincipalPassword)) {
-            CallbackHandler callbackHandler = getUsernamePasswordHandler(servicePrincipalName, servicePrincipalPassword);
+            CallbackHandler callbackHandler = getUsernamePasswordHandler(servicePrincipalName,
+                    servicePrincipalPassword.toCharArray());
             // create kerberos server credentials for IS
             localIWACredentials = createServerCredentials(callbackHandler);
             serverPrincipal = new KerberosPrincipal(localIWACredentials.getName().toString());
@@ -121,6 +122,7 @@ public class IWAAuthenticationUtil {
      * @throws GSSException
      */
     public static String processToken(byte[] gssToken) throws GSSException {
+        // TODO : create the local credentials here and do the processing of kerberos token
         return processToken(gssToken, localIWACredentials);
     }
 
@@ -157,7 +159,9 @@ public class IWAAuthenticationUtil {
     }
 
     /**
-     * Create server credential using SPN
+     * Create server credential using SPNName and SPNPassword. This credential is used to decrypt the Kerberos Token
+     * presented by the user. Although an actual authentication does not happen with the KDC, an invalid password
+     * will result in checksum failure when decrypting the token.
      *
      * @param callbackHandler username password callback handler
      * @throws PrivilegedActionException
@@ -165,7 +169,6 @@ public class IWAAuthenticationUtil {
      */
     private static GSSCredential createServerCredentials(CallbackHandler callbackHandler)
             throws PrivilegedActionException, LoginException {
-        // authenticate to the AD (Kerberos Server)
         LoginContext loginContext = new LoginContext(IWAConstants.SERVER, callbackHandler);
         loginContext.login();
 
@@ -212,7 +215,7 @@ public class IWAAuthenticationUtil {
      * @param password
      * @return CallbackHandler
      */
-    private static CallbackHandler getUsernamePasswordHandler(final String username, final String password) {
+    private static CallbackHandler getUsernamePasswordHandler(final String username, final char[] password) {
         final CallbackHandler handler = new CallbackHandler() {
             public void handle(final Callback[] callback) {
                 for (int i = 0; i < callback.length; i++) {
@@ -222,7 +225,7 @@ public class IWAAuthenticationUtil {
                         nameCallback.setName(username);
                     } else if (currentCallBack instanceof PasswordCallback) {
                         final PasswordCallback passCallback = (PasswordCallback) currentCallBack;
-                        passCallback.setPassword(password.toCharArray());
+                        passCallback.setPassword(password);
                     } else {
                         log.error("Unsupported Callback i = " + i + "; class = " + currentCallBack.getClass().getName());
                     }
@@ -233,22 +236,9 @@ public class IWAAuthenticationUtil {
         return handler;
     }
 
-
-    /**
-     * get GSSCredentials for a particular KDC server
-     *
-     * @param kdcServerURL URL of the Kerberos Server
-     * @return
-     */
-    public static GSSCredential getCredentials(String kdcServerURL) {
-        return gssCredentialMap.get(kdcServerURL);
-    }
-
-
     /**
      * Create GSSCredentials to communicate with a Kerberos Server
      *
-     * @param kdcServer   URL of the Kerberos Server
      * @param SPNName     Service Principal Name for the Identity Server
      * @param SPNPassword Service Principal password
      * @return created GSSCredentials
@@ -256,15 +246,58 @@ public class IWAAuthenticationUtil {
      * @throws LoginException
      * @throws GSSException
      */
-    public static GSSCredential createCredentials(String kdcServer, String SPNName, String SPNPassword)
+    public static GSSCredential createCredentials(String SPNName, char[] SPNPassword)
             throws PrivilegedActionException, LoginException, GSSException {
 
         CallbackHandler callbackHandler = getUsernamePasswordHandler(SPNName, SPNPassword);
-        GSSCredential gssCredential = createServerCredentials(callbackHandler);
+        return createServerCredentials(callbackHandler);
+    }
 
-        // add the created credentials to the map
-        gssCredentialMap.put(kdcServer.toLowerCase(), gssCredential);
-        return gssCredential;
+    /**
+     * Util Method to extract the Realm (Domain) name from a fullyQualified user name
+     * eg: admin@IS.LOCAL --> IS.LOCAL
+     *
+     * @param fullyQualifiedUserName
+     * @return
+     */
+    public static String extractRealmFromUserName(String fullyQualifiedUserName) {
+        if (StringUtils.isEmpty(fullyQualifiedUserName)) {
+            throw new IllegalArgumentException("Authenticated user's fully qualified name cannot be empty.");
+        }
+
+        // remove the AD domain from the username
+        int index = fullyQualifiedUserName.lastIndexOf("@");
+        return fullyQualifiedUserName.substring(index+1);
+    }
+
+    /**
+     * Util method to get the domain/realm aware username from the fullyQualified username
+     * eg: admin@IS.LOCAL --> admin
+     *
+     * @param fullyQualifiedUserName
+     * @return
+     */
+    public static String getDomainAwareUserName(String fullyQualifiedUserName) {
+        if (StringUtils.isEmpty(fullyQualifiedUserName)) {
+            throw new IllegalArgumentException("Authenticated user's fully qualified name cannot be empty.");
+        }
+
+        // remove the AD domain from the username
+        int index = fullyQualifiedUserName.lastIndexOf("@");
+        return fullyQualifiedUserName.substring(0, index);
+    }
+
+    /**
+     * Invalide a session. This is to prevent session fixation attacks
+     * @param request
+     */
+    public static void invalidateSession(HttpServletRequest request) {
+        if (request.isRequestedSessionIdValid()) {
+            // invalidate the session. ie. clear all attributes
+            request.getSession().invalidate();
+            // create a new session thereby creating a new jSessionID
+            request.getSession(true);
+        }
     }
 
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
@@ -247,17 +247,17 @@ public class IWAAuthenticationUtil {
     /**
      * Create GSSCredentials to communicate with a Kerberos Server
      *
-     * @param SPNName     Service Principal Name for the Identity Server
-     * @param SPNPassword Service Principal password
+     * @param spnName     Service Principal Name for the Identity Server
+     * @param spnPassword Service Principal password
      * @return created GSSCredentials
      * @throws PrivilegedActionException
      * @throws LoginException
      * @throws GSSException
      */
-    public static GSSCredential createCredentials(String SPNName, char[] SPNPassword)
+    public static GSSCredential createCredentials(String spnName, char[] spnPassword)
             throws PrivilegedActionException, LoginException, GSSException {
 
-        CallbackHandler callbackHandler = getUserNamePasswordCallbackHandler(SPNName, SPNPassword);
+        CallbackHandler callbackHandler = getUserNamePasswordCallbackHandler(spnName, spnPassword);
         return createServerCredentials(callbackHandler);
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticationUtil.java
@@ -71,6 +71,7 @@ public class IWAAuthenticationUtil {
 
         char[] servicePrincipalPassword = new char[0];
         if (realmConfiguration.getUserStoreProperties().containsKey(IWAConstants.SPN_PASSWORD)) {
+            // this check is needed since UserStoreProperties is a hashMap and therefore null values are possible.
             if (StringUtils.isNotBlank(realmConfiguration.getUserStoreProperty(IWAConstants.SPN_PASSWORD))) {
                 servicePrincipalPassword =
                         realmConfiguration.getUserStoreProperty(IWAConstants.SPN_PASSWORD).toCharArray();

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
@@ -69,7 +69,7 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
         GSSCredential gssCredential;
         try {
             // URL of the Kerberos Server that issues the token the user will authenticate with.
-            String kdcServer = (String) authenticatorProperties.get(IWAConstants.KERBEROS_SERVER);
+            String kdcServerUrl = (String) authenticatorProperties.get(IWAConstants.KERBEROS_SERVER);
 
             // Service Principal Name : an identifier representing IS registered at the Kerberos Server, this can
             // sometimes be the service account of the IS at the Kerberos Server
@@ -78,10 +78,17 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
             // Password of the service account of IS at the Kerberos Server
             char[] spnPassword = authenticatorProperties.get(IWAConstants.SPN_PASSWORD).toString().toCharArray();
 
-            if (StringUtils.isBlank(kdcServer) || StringUtils.isBlank(spnName) || ArrayUtils.isEmpty(spnPassword)) {
-                throw new AuthenticationFailedException
-                        ("Kerberos Server/Service Principal Name/Service Principal Password cannot " +
-                                "be empty to create credentials for KDC : " + kdcServer);
+            String errorMsg = null;
+            if (StringUtils.isBlank(kdcServerUrl)) {
+                errorMsg = "Kerberos Server URL cannot be empty.";
+            } else if (StringUtils.isBlank(spnName)) {
+                errorMsg = "Service Principal Name (SPN) cannot be empty.";
+            } else if (ArrayUtils.isEmpty(spnPassword)) {
+                errorMsg = "Service Principal password cannot be empty.";
+            }
+
+            if (errorMsg != null) {
+                throw new AuthenticationFailedException(errorMsg);
             }
 
             // create credentials to decrypt the Kerberos Token used to authenticate the user

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authenticator.iwa;
 
 
 import org.apache.axiom.om.util.Base64;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -35,6 +36,7 @@ import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.security.auth.login.LoginException;
 import javax.servlet.http.HttpServletRequest;
@@ -74,16 +76,16 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
             String spnName = (String) authenticatorProperties.get(IWAConstants.SPN_NAME);
 
             // Password of the service account of IS at the Kerberos Server
-            String spnPassword = (String) authenticatorProperties.get(IWAConstants.SPN_PASSWORD);
+            char[] spnPassword = authenticatorProperties.get(IWAConstants.SPN_PASSWORD).toString().toCharArray();
 
-            if (StringUtils.isBlank(kdcServer) || StringUtils.isBlank(spnName) || StringUtils.isBlank(spnPassword)) {
+            if (StringUtils.isBlank(kdcServer) || StringUtils.isBlank(spnName) || ArrayUtils.isEmpty(spnPassword)) {
                 throw new AuthenticationFailedException
                         ("Kerberos Server/Service Principal Name/Service Principal Password cannot " +
                                 "be empty to create credentials for KDC : " + kdcServer);
             }
 
             // create credentials to decrypt the Kerberos Token used to authenticate the user
-            gssCredential = IWAAuthenticationUtil.createCredentials(spnName, spnPassword.toCharArray());
+            gssCredential = IWAAuthenticationUtil.createCredentials(spnName, spnPassword);
 
         } catch (PrivilegedActionException | LoginException | GSSException ex) {
             throw new AuthenticationFailedException("Cannot create kerberos credentials for server.", ex);
@@ -148,4 +150,5 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
             throw new AuthenticationFailedException("Error processing the GSS Token", e);
         }
     }
+
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
@@ -113,20 +113,20 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
         kerberosServerURL.setDescription("Kerberos Server");
         configProperties.add(kerberosServerURL);
 
-        Property SPNName = new Property();
-        SPNName.setName(IWAConstants.SPN_NAME);
-        SPNName.setDisplayName("Service Principal Name");
-        SPNName.setRequired(true);
-        SPNName.setDescription("Kerberos Service Principal Name");
-        configProperties.add(SPNName);
+        Property spnName = new Property();
+        spnName.setName(IWAConstants.SPN_NAME);
+        spnName.setDisplayName("Service Principal Name");
+        spnName.setRequired(true);
+        spnName.setDescription("Kerberos Service Principal Name");
+        configProperties.add(spnName);
 
-        Property SPNPassword = new Property();
-        SPNPassword.setName(IWAConstants.SPN_PASSWORD);
-        SPNPassword.setDisplayName("Service Principal Password");
-        SPNPassword.setRequired(true);
-        SPNPassword.setDescription("Kerberos Service Principal Password");
-        SPNPassword.setConfidential(true);
-        configProperties.add(SPNPassword);
+        Property spnPassword = new Property();
+        spnPassword.setName(IWAConstants.SPN_PASSWORD);
+        spnPassword.setDisplayName("Service Principal Password");
+        spnPassword.setRequired(true);
+        spnPassword.setDescription("Kerberos Service Principal Password");
+        spnPassword.setConfidential(true);
+        configProperties.add(spnPassword);
 
         return configProperties;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWALocalAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWALocalAuthenticator.java
@@ -120,8 +120,7 @@ public class IWALocalAuthenticator extends AbstractIWAAuthenticator implements
         RealmService realmService = IWAServiceDataHolder.getInstance().getRealmService();
         int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
 
-        return (org.wso2.carbon.user.core.UserStoreManager) realmService.getTenantUserRealm(tenantId)
-                .getUserStoreManager();
+        return (UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager();
     }
 
     /**
@@ -135,7 +134,7 @@ public class IWALocalAuthenticator extends AbstractIWAAuthenticator implements
             AuthenticationFailedException {
         UserStoreManager userStoreManager;
         try {
-            userStoreManager = getPrimaryUserStoreManager(tenantDomain).getSecondaryUserStoreManager().getSecondaryUserStoreManager();
+            userStoreManager = getPrimaryUserStoreManager(tenantDomain);
             String userStoreDomain = IdentityUtil.getPrimaryDomainName();
             authenticatedUserName = IdentityUtil.addDomainToName(authenticatedUserName, userStoreDomain);
 

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWALocalAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWALocalAuthenticator.java
@@ -61,7 +61,7 @@ public class IWALocalAuthenticator extends AbstractIWAAuthenticator implements
 
         HttpSession session = request.getSession(false);
         String gssToken = (String) session.getAttribute(IWAConstants.KERBEROS_TOKEN);
-        invalidateSession(request);
+        IWAAuthenticationUtil.invalidateSession(request);
 
         // get the authenticated username by processing the GSS Token
         String fullyQualifiedName;
@@ -72,28 +72,14 @@ public class IWALocalAuthenticator extends AbstractIWAAuthenticator implements
         }
 
         if (IdentityUtil.isBlank(fullyQualifiedName)) {
-            throw new AuthenticationFailedException("Authenticated user not found in GSS Token : "
-                    + fullyQualifiedName);
+            throw new AuthenticationFailedException("Authenticated user not found in GSS Token : " +
+                    fullyQualifiedName);
         }
 
-        String authenticatedUserName = getDomainAwareUserName(fullyQualifiedName);
-
-        boolean isExistInPrimaryUserStore;
-        UserStoreManager userStoreManager;
+        String authenticatedUserName = IWAAuthenticationUtil.getDomainAwareUserName(fullyQualifiedName);
+        String realm = IWAAuthenticationUtil.extractRealmFromUserName(fullyQualifiedName);
         String spTenantDomain = context.getTenantDomain();
-        try {
-            userStoreManager = getPrimaryUserStoreManager(spTenantDomain);
-            String userStoreDomain = IdentityUtil.getPrimaryDomainName();
-            authenticatedUserName = IdentityUtil.addDomainToName(authenticatedUserName, userStoreDomain);
-
-            // Check whether the authenticated user is in primary user store. This is a limitation and will be improved
-            // to support ADs mounted as secondary user stores
-            isExistInPrimaryUserStore =
-                    userStoreManager.isExistingUser(MultitenantUtils.getTenantAwareUsername(authenticatedUserName));
-
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new AuthenticationFailedException("IWALocalAuthenticator failed to find the user in the userstore", e);
-        }
+        boolean isExistInPrimaryUserStore = isExistsInUserStore(authenticatedUserName, spTenantDomain, realm);
 
         if (!isExistInPrimaryUserStore) {
             String msg = "User " + authenticatedUserName + "not found in the user store of tenant " + spTenantDomain;
@@ -134,6 +120,32 @@ public class IWALocalAuthenticator extends AbstractIWAAuthenticator implements
         RealmService realmService = IWAServiceDataHolder.getInstance().getRealmService();
         int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
 
-        return (UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager();
+        return (org.wso2.carbon.user.core.UserStoreManager) realmService.getTenantUserRealm(tenantId)
+                .getUserStoreManager();
+    }
+
+    /**
+     * Check whether the authenticated user exists in any user store that belongs to the realm the user belongs to.
+     *
+     * @param authenticatedUserName
+     * @param tenantDomain
+     * @return
+     */
+    private boolean isExistsInUserStore(String authenticatedUserName, String tenantDomain, String realm) throws
+            AuthenticationFailedException {
+        UserStoreManager userStoreManager;
+        try {
+            userStoreManager = getPrimaryUserStoreManager(tenantDomain).getSecondaryUserStoreManager().getSecondaryUserStoreManager();
+            String userStoreDomain = IdentityUtil.getPrimaryDomainName();
+            authenticatedUserName = IdentityUtil.addDomainToName(authenticatedUserName, userStoreDomain);
+
+            // Check whether the authenticated user is in primary user store. This is a limitation and will be improved
+            // to support ADs mounted as secondary user stores
+            return userStoreManager.isExistingUser(MultitenantUtils.getTenantAwareUsername(authenticatedUserName));
+
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException("IWALocalAuthenticator failed to find the user in the userstore", e);
+        }
+
     }
 }

--- a/features/org.wso2.carbon.identity.application.authenticator.iwa.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.iwa.server.feature/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.local.auth.iwa</groupId>
             <artifactId>org.wso2.carbon.identity.application.authenticator.iwa</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
         <dependencies>
             <!--Orbit Dependencies-->
             <dependency>
+                <groupId>commons-lang.wso2</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.wso2.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.axis2.wso2</groupId>
                 <artifactId>axis2</artifactId>
                 <version>${axis2.wso2.version}</version>
@@ -137,6 +142,7 @@
                 <artifactId>axis2-client</artifactId>
                 <version>${axis2.wso2.version}</version>
             </dependency>
+
 
             <!--Carbon Identity Framework Dependencies-->
             <dependency>
@@ -149,6 +155,14 @@
                 <artifactId>org.wso2.carbon.identity.application.common</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.wso2.carbon.identity.local.auth.iwa</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authenticator.iwa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+
 
         </dependencies>
     </dependencyManagement>
@@ -234,6 +248,8 @@
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 
         <!-- Commons -->
+        <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
+
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
 


### PR DESCRIPTION
- Removed storing credentials in an in-memory concurrent hashmap.
- Moving Util methods from authenticators.
- Use char array for passwords.
- Minor refactoring.
