### PR TITLE
IWAFederatedAuthenticator fix

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
@@ -112,7 +112,7 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
 
         if (StringUtils.isEmpty(userStoreDomain)) {
             context.setSubject(
-                    AuthenticatedUser.createFederateAuthenticatedUserFromSubjectIdentifier(authenticatedUserName));
+                    AuthenticatedUser.createFederateAuthenticatedUserFromSubjectIdentifier(fullyQualifiedName));
         } else {
 
 
@@ -249,7 +249,7 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
             return userStoreManager.isExistingUser(userNameWithUserStoreDomain);
 
         } catch (UserStoreException e) {
-            String errorMsg = "Error when searching for user: %s in '%' userStoreDomain in '%s' tenant.";
+            String errorMsg = "Error when searching for user: %s in '%s' userStoreDomain in '%s' tenant.";
             throw new AuthenticationFailedException(
                     String.format(errorMsg, authenticatedUserName, userStoreDomain, tenantDomain), e);
         }


### PR DESCRIPTION
1. Fix error in String.format pattern
2. Set full the authenticated username from the GSS Token into subject (information of domain name is losted)