### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
@@ -128,6 +128,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/test/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/test/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticatorTest.java
@@ -30,11 +30,13 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authenticator.iwa.internal.IWAServiceDataHolder;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import org.wso2.carbon.user.core.UserRealm;
@@ -468,6 +470,9 @@ public class IWAAuthenticatorTest extends PowerMockIdentityBaseTest {
         setMockIWAAuthenticationUtil();
         setMockUserCoreUtil();
 
+        IdentityTenantUtil.setRealmService(mockRealmService);
+        when(mockRealmService.getTenantManager().getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
         mockSession.setAttribute(IWAConstants.KERBEROS_TOKEN, Base64.encode(token));
         when(mockUserStoreManager.isExistingUser(anyString())).thenReturn(true);
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-local-auth-iwa-kerberos.git
         </developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-local-auth-iwa-kerberos.git</connection>
-        <tag>v5.4.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 
@@ -260,10 +260,10 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.7.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
         <carbon.identity.package.export.version>${carbon.identity.framework.version}
         </carbon.identity.package.export.version>
-        <carbon.identity.package.import.version.range>[5.7.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
 
         <project.scm.id>my-scm-server</project.scm.id>
 
@@ -274,7 +274,7 @@
         <slf4j.api.version>1.7.12</slf4j.api.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.6</powermock.version>
-        <org.wso2.carbon.identity.testutil.version>5.10.51</org.wso2.carbon.identity.testutil.version>
+        <org.wso2.carbon.identity.testutil.version>6.0.0</org.wso2.carbon.identity.testutil.version>
     </properties>
 
 </project>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16