### PR TITLE
Tenant Qualify Kerberos URLs

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>org.wso2.carbon.identity.application.common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -69,6 +73,14 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -127,6 +139,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/AbstractIWAAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/AbstractIWAAuthenticator.java
@@ -23,7 +23,8 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -76,13 +77,14 @@ public abstract class AbstractIWAAuthenticator extends AbstractApplicationAuthen
      */
     private void sendToLoginPage(HttpServletRequest request, HttpServletResponse response, String ctx)
             throws AuthenticationFailedException {
+
         String iwaURL = null;
         try {
-
-            iwaURL = IdentityUtil.getServerURL(IWAConstants.IWA_AUTH_EP, false, true) +
+            iwaURL = ServiceURLBuilder.create().addPath(IWAConstants.IWA_AUTH_EP).build().getAbsolutePublicURL() +
                     "?" + IWAConstants.IWA_PARAM_STATE + "=" + URLEncoder.encode(ctx, IWAConstants.UTF_8);
             response.sendRedirect(iwaURL);
-
+        } catch (URLBuilderException e) {
+            throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
         } catch (IOException e) {
             String msg = "Error when redirecting to the login page : " + iwaURL;
             throw new AuthenticationFailedException(msg, e);

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/servlet/IWAServlet.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/servlet/IWAServlet.java
@@ -23,7 +23,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authenticator.iwa.IWAAuthenticationUtil;
 import org.wso2.carbon.identity.application.authenticator.iwa.IWAConstants;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -49,8 +50,15 @@ public class IWAServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        String commonAuthURL = IdentityUtil.getServerURL(IWAConstants.COMMON_AUTH_EP, false, true);
+            throws ServletException, IOException, RuntimeException {
+
+        String commonAuthURL;
+        try {
+            commonAuthURL =
+                    ServiceURLBuilder.create().addPath(IWAConstants.COMMON_AUTH_EP).build().getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
+        }
         String param = request.getParameter(IWAConstants.IWA_PARAM_STATE);
         if (param == null) {
             throw new IllegalArgumentException(IWAConstants.IWA_PARAM_STATE + " parameter is null.");

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
                 <artifactId>org.wso2.carbon.identity.application.common</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.local.auth.iwa</groupId>
@@ -136,6 +141,17 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
                 <version>${org.wso2.carbon.identity.testutil.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -191,8 +207,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -260,7 +276,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.7.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.360</carbon.identity.framework.version>
         <carbon.identity.package.export.version>${carbon.identity.framework.version}
         </carbon.identity.package.export.version>
         <carbon.identity.package.import.version.range>[5.7.0, 7.0.0)</carbon.identity.package.import.version.range>
@@ -274,7 +290,9 @@
         <slf4j.api.version>1.7.12</slf4j.api.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.6</powermock.version>
-        <org.wso2.carbon.identity.testutil.version>5.10.51</org.wso2.carbon.identity.testutil.version>
+        <org.wso2.carbon.identity.testutil.version>5.25.360</org.wso2.carbon.identity.testutil.version>
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        </org.wso2.carbon.identity.organization.management.core.version>
     </properties>
 
 </project>


### PR DESCRIPTION
This PR builds the /iwa-kerberos and /commonauth URLs using the ServiceURLBuilder instead of the IdentityUtils.getServerUrl method.

Related Issue: https://github.com/wso2/product-is/issues/9006