### PR TITLE
Resolve user from multi attribute login

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/pom.xml
@@ -82,6 +82,10 @@
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -120,6 +124,8 @@
                             org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}",
 
                             org.wso2.carbon.identity.application.authentication.framework.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/internal/IWAAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/internal/IWAAuthenticatorServiceComponent.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Application
 import org.wso2.carbon.identity.application.authenticator.iwa.IWAConstants;
 import org.wso2.carbon.identity.application.authenticator.iwa.IWAFederatedAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.iwa.servlet.IWAServlet;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import javax.servlet.Servlet;
@@ -42,6 +43,10 @@ import javax.servlet.ServletException;
  * interface="org.wso2.carbon.user.core.service.RealmService"
  * cardinality="1..1" policy="dynamic" bind="setRealmService"
  * unbind="unsetRealmService"
+ * @scr.reference name="MultiAttributeLoginService"
+ * interface="org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService"
+ * cardinality="1..1" policy="dynamic" bind="setMultiAttributeLoginService"
+ * unbind="unsetMultiAttributeLoginService"
  */
 public class IWAAuthenticatorServiceComponent {
 
@@ -103,5 +108,21 @@ public class IWAAuthenticatorServiceComponent {
             log.debug("Unsetting the Realm Service");
         }
         dataHolder.setRealmService(null);
+    }
+
+    protected void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Multi Attribute Login Service");
+        }
+        dataHolder.setMultiAttributeLoginService(multiAttributeLoginService);
+    }
+
+    protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting the Multi Attribute Login Service");
+        }
+        dataHolder.setMultiAttributeLoginService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/internal/IWAServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/internal/IWAServiceDataHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authenticator.iwa.internal;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.http.HttpService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -29,6 +30,7 @@ public class IWAServiceDataHolder {
 
     private HttpService httpService;
     private RealmService realmService;
+    private MultiAttributeLoginService multiAttributeLoginService;
     private static final Log log = LogFactory.getLog(IWAServiceDataHolder.class);
 
     private static IWAServiceDataHolder instance = new IWAServiceDataHolder();
@@ -60,5 +62,15 @@ public class IWAServiceDataHolder {
 
     public void setHttpService(HttpService httpService) {
         this.httpService = httpService;
+    }
+
+    public MultiAttributeLoginService getMultiAttributeLoginService() {
+
+        return multiAttributeLoginService;
+    }
+
+    public void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        this.multiAttributeLoginService = multiAttributeLoginService;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/test/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/test/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticatorTest.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -103,6 +104,9 @@ public class IWAAuthenticatorTest extends PowerMockIdentityBaseTest {
 
     @Mock
     RealmService mockRealmService;
+
+    @Mock
+    MultiAttributeLoginService mockMultiAttributeLoginService;
 
     @Mock
     TenantManager mockTenantManager;
@@ -226,6 +230,7 @@ public class IWAAuthenticatorTest extends PowerMockIdentityBaseTest {
     private void initCommonMocks() throws Exception{
 
         dataHolder.setRealmService(mockRealmService);
+        dataHolder.setMultiAttributeLoginService(mockMultiAttributeLoginService);
         when(mockHttpRequest.getSession(anyBoolean())).thenReturn(mockSession);
         when(mockHttpRequest.getSession()).thenReturn(mockSession);
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### Purpose

If the user exists in an userstore where the username is configured to use any other attribute than `sAMAccountName` or `userPrincipalName` returned with the GSS token, we need to use the configured attribute to check if the user is existing. This pr introduces multi attribute login feature to kerberos authenticator to resolve the user in such scenarios. 

### Related issues
- https://github.com/wso2/product-is/issues/20565 