### PR TITLE
Update the java version used in the mvn compiler plugin to java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,8 +293,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Purpose

Updating the java version to 8 to fix failing jenkins build since a method reference was introduced with https://github.com/wso2-extensions/identity-local-auth-iwa-kerberos/pull/78