### PR TITLE
Fix tenant domain resolving

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java
@@ -133,7 +133,7 @@ public class IWAFederatedAuthenticator extends AbstractIWAAuthenticator implemen
             AuthenticatedUser authenticatedUser = new AuthenticatedUser();
             authenticatedUser.setUserName(iwaAuthenticatedUserBean.getUser());
             authenticatedUser.setUserStoreDomain(iwaAuthenticatedUserBean.getUserStoreDomain());
-            authenticatedUser.setTenantDomain(MultitenantUtils.getTenantDomain(iwaAuthenticatedUserBean.getTenantDomain()));
+            authenticatedUser.setTenantDomain(iwaAuthenticatedUserBean.getTenantDomain());
             authenticatedUser.setAuthenticatedSubjectIdentifier(iwaAuthenticatedUserBean.getUser());
             authenticatedUser.setUserAttributes(
                     IWAAuthenticationUtil.buildClaimMappingMap(getUserClaims(iwaAuthenticatedUserBean)));


### PR DESCRIPTION
### Purpose
Minor bug fix in tenant domain resolving[1].

fix: authenticatedUser.setTenantDomain(iwaAuthenticatedUserBean.getTenantDomain());

[1] https://github.com/wso2-extensions/identity-local-auth-iwa-kerberos/blob/v5.4.8/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAFederatedAuthenticator.java#L136


### Related Issues:
- https://github.com/wso2/product-is/issues/26424

### Related PRs:

