### PR TITLE
Fix Null pointer exception and krb5.conf path.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAConstants.java
@@ -50,7 +50,7 @@ public class IWAConstants {
     public static final String JAAS_CONFIG_PROPERTY = "java.security.auth.login.config";
     public static final String JAAS_CONF_FILE_NAME = "jaas.conf";
 
-    public static final String KERBEROS_CONFIG_PROPERTY = "java.security.auth.krb5.conf";
+    public static final String KERBEROS_CONFIG_PROPERTY = "java.security.krb5.conf";
     public static final String KERBEROS_CONF_FILE_NAME = "krb5.conf";
 
     private IWAConstants() {

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/servlet/IWAServlet.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/servlet/IWAServlet.java
@@ -152,6 +152,8 @@ public class IWAServlet extends HttpServlet {
 
     @Override
     public void init(ServletConfig config) throws ServletException {
+
+        super.init(config);
         // set the kerberos config path
         IWAAuthenticationUtil.setConfigFilePaths();
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.iwa/src/test/resources/home/repository/conf/identity/krb5.conf
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa/src/test/resources/home/repository/conf/identity/krb5.conf
@@ -1,8 +1,9 @@
 [libdefaults]
         default_realm = IS.LOCAL
-        default_tkt_enctypes = rc4-hmac
-        default_tgs_enctypes = rc4-hmac
-        dns_lookup_kdc = true
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+        dns_lookup_kdc = false
         dns_lookup_realm = false
 
 [realms]


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/28011
- [x] https://github.com/wso2/product-is/issues/16776

This pull request makes two targeted updates to the IWA authenticator module: one corrects a system property constant for Kerberos configuration, and the other ensures proper servlet initialization by calling the superclass's `init` method.

Configuration constant correction:

* Updated the value of `KERBEROS_CONFIG_PROPERTY` in `IWAConstants.java` from `"java.security.auth.krb5.conf"` to the correct `"java.security.krb5.conf"`, ensuring the application uses the proper system property for Kerberos configuration.

Servlet initialization improvement:

* Added a call to `super.init(config)` in the `init` method of `IWAServlet.java` to ensure the servlet is initialized correctly according to the servlet lifecycle.